### PR TITLE
change chinese translation

### DIFF
--- a/i18n/zh_CN.json
+++ b/i18n/zh_CN.json
@@ -1,3 +1,3 @@
 {
-  "addTopBarIcon": "打开菜单"
+  "addTopBarIcon": "打开quickSnippets菜单"
 }

--- a/i18n/zh_CN.json
+++ b/i18n/zh_CN.json
@@ -1,3 +1,3 @@
 {
-  "addTopBarIcon": "打开quickSnippets菜单"
+  "addTopBarIcon": "打开 quickSnippets 菜单"
 }


### PR DESCRIPTION
 - 因为“打开菜单”这个名称出现在手机的右侧菜单会让用户摸不着头脑  
 - 没有把“quickSnippets”也改为中文，是为了遵照该插件没有官方中文名  